### PR TITLE
Atualizar página pedidos para comportamento dinâmico

### DIFF
--- a/PAGINA_PEDIDOS_DINAMICA.md
+++ b/PAGINA_PEDIDOS_DINAMICA.md
@@ -1,0 +1,147 @@
+# Página de Pedidos Dinâmica - Implementação
+
+## Resumo das Modificações
+
+A página `/pedidos` foi completamente redesenhada para ser dinâmica e funcionar como uma experiência integrada de "Meus Pedidos", eliminando a necessidade de pop-ups e criando um fluxo mais intuitivo.
+
+## Principais Mudanças
+
+### 1. **Comportamento Dinâmico**
+- **Usuário Novo/Desconhecido**: Exibe formulário de busca por telefone
+- **Usuário Conhecido**: Mostra diretamente os pedidos na página principal
+- **Identificação Automática**: Usa localStorage para lembrar usuários anteriores
+
+### 2. **Interface Adaptativa**
+
+#### Para Novos Usuários:
+- Formulário de busca por telefone
+- Guia de como usar
+- Lista de status dos pedidos
+- Layout educativo e acolhedor
+
+#### Para Usuários Conhecidos:
+- Header com informações do cliente (telefone, total de pedidos, valor gasto)
+- Botão "Trocar Usuário" para permitir login com outro telefone
+- Pedidos organizados em duas seções:
+  - **Pedidos em Andamento**: Status PENDING, CONFIRMED, PREPARING, READY, OUT_DELIVERY
+  - **Histórico de Pedidos**: Status DELIVERED, CANCELLED
+
+### 3. **Funcionalidades Implementadas**
+
+#### Identificação Automática:
+```typescript
+// Verificação do localStorage na inicialização
+const storedWhatsApp = localStorage.getItem('customerWhatsApp');
+if (storedWhatsApp) {
+  // Busca automática dos pedidos
+  // Remove formulário de busca
+  // Exibe pedidos diretamente
+}
+```
+
+#### Gestão de Estado:
+- `showSearchForm`: Controla se exibe formulário ou pedidos
+- `knownCustomerPhone`: Armazena telefone formatado do usuário conhecido
+- `currentCustomerId`: ID do cliente para buscar pedidos
+- `expandedOrders`: Controla quais pedidos estão expandidos
+
+#### Fluxo Pós-Pagamento:
+- URL com parâmetro `?from=payment-success` identifica chegada via pagamento
+- Mensagem de boas-vindas personalizada
+- Limpeza automática de dados temporários
+
+### 4. **Exibição dos Pedidos**
+
+#### Componente OrderDetails:
+- Cards expansíveis para cada pedido
+- Loading assíncrono dos itens do pedido
+- Detalhes completos: itens, valores, endereço, pagamento
+- Botão "Repetir" para pedidos entregues
+
+#### Organização Visual:
+- Separação clara entre pedidos atuais e histórico
+- Ícones e badges coloridos para status
+- Design responsivo e acessível
+
+### 5. **Recursos de UX**
+
+#### Gestão de Usuário:
+- Botão "Trocar Usuário" remove dados do localStorage
+- Permite usar a página com diferentes telefones
+- Feedback visual com toasts informativos
+
+#### Ações Rápidas:
+- "Repetir Pedido" adiciona itens ao carrinho
+- "Fazer Novo Pedido" redireciona para cardápio
+- "Fazer Primeiro Pedido" para usuários sem histórico
+
+### 6. **Estados da Interface**
+
+#### Loading States:
+- Spinner durante carregamento dos pedidos
+- Loading individual para itens de cada pedido
+
+#### Empty States:
+- Mensagem para usuários sem pedidos
+- CTA para fazer primeiro pedido
+
+#### Error Handling:
+- Fallback para formulário se auto-login falhar
+- Mensagens de erro contextuais
+
+## Integração com o Fluxo de Pagamento
+
+### Antes:
+1. Pagamento → Success Page → Redirecionamento para /pedidos
+2. Página sempre mostrava formulário
+3. Modal pop-up para exibir pedidos
+
+### Depois:
+1. Pagamento → Success Page → /pedidos?from=payment-success
+2. Identificação automática via localStorage
+3. Exibição direta dos pedidos na página
+4. Mensagem de boas-vindas personalizada
+
+## Armazenamento de Dados
+
+### localStorage:
+- `customerWhatsApp`: Número do telefone (sem formatação)
+- `lastPaymentOrder`: Dados temporários do último pedido (limpo automaticamente)
+
+### Fluxo de Dados:
+1. **Checkout**: Salva WhatsApp no localStorage
+2. **Payment Success**: Verifica localStorage e redireciona
+3. **Página Pedidos**: Busca automática se WhatsApp existe
+4. **Futuras Visitas**: Acesso direto aos pedidos
+
+## Benefícios da Nova Implementação
+
+1. **UX Melhorada**: Elimina etapas desnecessárias
+2. **Redução de Friction**: Usuários conhecidos veem pedidos imediatamente
+3. **Contexto Preservado**: Lembra preferências e histórico
+4. **Mobile-Friendly**: Interface responsiva e touch-friendly
+5. **Acessibilidade**: Melhor navegação e feedback visual
+
+## Componentes Removidos/Modificados
+
+- **Removido**: `OrderHistoryModal` (funcionalidade integrada na página)
+- **Modificado**: Lógica de identificação automática
+- **Adicionado**: Componente `OrderDetails` inline
+- **Adicionado**: Sistema de alternância entre formulário/pedidos
+
+## Considerações Técnicas
+
+### Performance:
+- Queries condicionais (só busca pedidos se tem customerId)
+- Loading lazy dos itens de pedido
+- Otimização de re-renders
+
+### Manutenibilidade:
+- Código modular e bem documentado
+- Separação clara de responsabilidades
+- Estados bem definidos
+
+### Escalabilidade:
+- Estrutura preparada para novos recursos
+- Fácil extensão do sistema de identificação
+- Componentização reutilizável

--- a/client/src/pages/pedidos.tsx
+++ b/client/src/pages/pedidos.tsx
@@ -4,8 +4,9 @@ import { Button } from "@/components/ui/button.js";
 import { Input } from "@/components/ui/input.js";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.js";
 import { Badge } from "@/components/ui/badge.js";
-import { Search, Package, Clock, CheckCircle, XCircle, RefreshCw } from "lucide-react";
-import { OrderHistoryModal } from "@/components/order-history-modal.js";
+import { Separator } from "@/components/ui/separator.js";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible.js";
+import { Search, Package, Clock, CheckCircle, XCircle, RefreshCw, History, RotateCcw, ShoppingCart, User, ChevronDown, ChevronUp, LogOut } from "lucide-react";
 import { useCart } from "@/hooks/use-cart.js";
 import { useToast } from "@/hooks/use-toast.js";
 import { api } from "@/lib/api.js";
@@ -27,8 +28,10 @@ const unformatPhone = (value: string) => {
 
 export default function Pedidos() {
   const [customerPhone, setCustomerPhone] = useState("");
-  const [isOrderHistoryOpen, setIsOrderHistoryOpen] = useState(false);
   const [currentCustomerId, setCurrentCustomerId] = useState<string | null>(null);
+  const [showSearchForm, setShowSearchForm] = useState(true);
+  const [expandedOrders, setExpandedOrders] = useState<Set<string>>(new Set());
+  const [knownCustomerPhone, setKnownCustomerPhone] = useState<string>("");
   const { addToCart, clearCart } = useCart();
   const { toast } = useToast();
 
@@ -37,54 +40,64 @@ export default function Pedidos() {
     queryFn: api.products.getAll
   });
 
-  // Identificação automática do cliente após pagamento bem-sucedido
+  const { data: orders = [], isLoading: isLoadingOrders } = useQuery({
+    queryKey: ["/api/orders/customer", currentCustomerId],
+    queryFn: () => currentCustomerId ? api.orders.getByCustomer(currentCustomerId) : Promise.resolve([]),
+    enabled: !!currentCustomerId
+  });
+
+  // Verificação automática do usuário conhecido
   useEffect(() => {
-    const checkAutoLogin = async () => {
-      // Verificar se chegou aqui via pagamento bem-sucedido
+    const checkKnownUser = async () => {
+      // Verificar se chegou via pagamento bem-sucedido
       const urlParams = new URLSearchParams(window.location.search);
       const fromPayment = urlParams.get('from') === 'payment-success';
       
       // Buscar WhatsApp armazenado
       const storedWhatsApp = localStorage.getItem('customerWhatsApp');
-      const lastPaymentOrder = localStorage.getItem('lastPaymentOrder');
       
-      if (fromPayment && storedWhatsApp) {
-        // Formatar o WhatsApp para exibição
+      if (storedWhatsApp) {
+        // Usuário conhecido - buscar automaticamente os pedidos
         const formattedWhatsApp = formatWhatsApp(storedWhatsApp);
+        setKnownCustomerPhone(formattedWhatsApp);
         setCustomerPhone(formattedWhatsApp);
+        setShowSearchForm(false);
         
         try {
-          // Buscar automaticamente os pedidos do cliente
           const unformattedPhone = unformatPhone(storedWhatsApp);
           const customer = await api.customers.getByWhatsapp(unformattedPhone);
           
           if (customer) {
             setCurrentCustomerId(customer.id);
-            setIsOrderHistoryOpen(true);
             
-            // Mostrar mensagem de sucesso
-            toast({
-              title: "🎉 Bem-vindo de volta!",
-              description: "Aqui estão seus pedidos. Seu último pedido já aparece no topo!",
-              duration: 5000,
-            });
-            
-            // Limpar dados temporários do localStorage
-            setTimeout(() => {
-              localStorage.removeItem('lastPaymentOrder');
-              // Manter customerWhatsApp para futuras visitas
-            }, 2000);
+            // Mostrar mensagem de boas-vindas se veio do pagamento
+            if (fromPayment) {
+              toast({
+                title: "🎉 Bem-vindo de volta!",
+                description: "Aqui estão seus pedidos. Seu último pedido já aparece no topo!",
+                duration: 5000,
+              });
+              
+              // Limpar dados temporários do localStorage
+              setTimeout(() => {
+                localStorage.removeItem('lastPaymentOrder');
+              }, 2000);
+            }
             
             // Limpar a URL para remover o parâmetro
-            window.history.replaceState({}, document.title, '/pedidos');
+            if (fromPayment) {
+              window.history.replaceState({}, document.title, '/pedidos');
+            }
           }
         } catch (error) {
           console.error('Erro ao buscar cliente automaticamente:', error);
+          // Se der erro, mostrar formulário de busca
+          setShowSearchForm(true);
         }
       }
     };
 
-    checkAutoLogin();
+    checkKnownUser();
   }, [toast]);
 
   const handleSearchOrders = async () => {
@@ -100,9 +113,19 @@ export default function Pedidos() {
     try {
       const unformattedPhone = unformatPhone(customerPhone);
       const customer = await api.customers.getByWhatsapp(unformattedPhone);
+      
       if (customer) {
         setCurrentCustomerId(customer.id);
-        setIsOrderHistoryOpen(true);
+        setKnownCustomerPhone(customerPhone);
+        setShowSearchForm(false);
+        
+        // Armazenar WhatsApp para futuras visitas
+        localStorage.setItem('customerWhatsApp', unformattedPhone);
+        
+        toast({
+          title: "Pedidos encontrados!",
+          description: "Visualizando seu histórico de pedidos",
+        });
       } else {
         toast({
           title: "Cliente não encontrado",
@@ -117,6 +140,20 @@ export default function Pedidos() {
         variant: "destructive"
       });
     }
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem('customerWhatsApp');
+    setCurrentCustomerId(null);
+    setKnownCustomerPhone("");
+    setCustomerPhone("");
+    setShowSearchForm(true);
+    setExpandedOrders(new Set());
+    
+    toast({
+      title: "Sessão encerrada",
+      description: "Você pode buscar pedidos com outro número de telefone",
+    });
   };
 
   const handleRepeatOrder = async (order: Order) => {
@@ -147,8 +184,7 @@ export default function Pedidos() {
         description: `${orderItems.length} itens foram adicionados ao carrinho`,
       });
       
-      // Close order history and redirect to checkout
-      setIsOrderHistoryOpen(false);
+      // Redirect to checkout
       window.location.href = '/checkout';
       
     } catch (error: any) {
@@ -158,6 +194,53 @@ export default function Pedidos() {
         variant: "destructive"
       });
     }
+  };
+
+  const toggleOrderExpansion = (orderId: string) => {
+    setExpandedOrders((prev: Set<string>) => {
+      const newSet = new Set(prev);
+      if (newSet.has(orderId)) {
+        newSet.delete(orderId);
+      } else {
+        newSet.add(orderId);
+      }
+      return newSet;
+    });
+  };
+
+  const getOrderItems = async (orderId: string) => {
+    try {
+      const response = await fetch(`/api/orders/${orderId}/items`);
+      if (!response.ok) {
+        throw new Error('Failed to fetch order items');
+      }
+      return await response.json();
+    } catch (error) {
+      console.error("Error fetching order items:", error);
+      return [];
+    }
+  };
+
+  const getProductName = (productId: string) => {
+    const product = products.find((p: any) => p.id === productId);
+    return product?.name || 'Produto não encontrado';
+  };
+
+  const formatCurrency = (value: number | string) => {
+    return new Intl.NumberFormat('pt-BR', {
+      style: 'currency',
+      currency: 'BRL'
+    }).format(Number(value));
+  };
+
+  const formatDate = (date: Date | string) => {
+    return new Date(date).toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
   };
 
   const getStatusIcon = (status: string) => {
@@ -179,7 +262,161 @@ export default function Pedidos() {
     }
   };
 
+  // Component to show order details
+  const OrderDetails = ({ order }: { order: Order }) => {
+    const [orderItems, setOrderItems] = useState<any[]>([]);
+    const [loadingItems, setLoadingItems] = useState(false);
+    const isExpanded = expandedOrders.has(order.id);
 
+    const fetchOrderItems = async () => {
+      if (isExpanded && orderItems.length === 0) {
+        setLoadingItems(true);
+        try {
+          const items = await getOrderItems(order.id);
+          setOrderItems(items);
+        } catch (error) {
+          console.error("Error fetching items:", error);
+        } finally {
+          setLoadingItems(false);
+        }
+      }
+    };
+
+    useEffect(() => {
+      if (isExpanded) {
+        fetchOrderItems();
+      }
+    }, [isExpanded]);
+
+    return (
+      <Collapsible open={isExpanded} onOpenChange={() => toggleOrderExpansion(order.id)}>
+        <div className="border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow">
+          <CollapsibleTrigger asChild>
+            <div className="w-full cursor-pointer">
+              <div className="flex justify-between items-start mb-2">
+                <span className="font-medium text-gray-900">Pedido #{order.order_number}</span>
+                <div className="flex items-center space-x-2">
+                  <span className="text-sm text-gray-500">{formatDate(order.created_at)}</span>
+                  {isExpanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+                </div>
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="font-semibold text-gray-900">
+                  {formatCurrency(order.total)}
+                </span>
+                <div className="flex items-center space-x-2">
+                  <Badge className={getStatusInfo(order.status).className}>
+                    {getStatusIcon(order.status)}
+                    <span className="ml-1">{getStatusInfo(order.status).label}</span>
+                  </Badge>
+                  {order.status === 'DELIVERED' && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleRepeatOrder(order);
+                      }}
+                      className="text-primary hover:text-orange-600"
+                    >
+                      <RotateCcw className="w-3 h-3 mr-1" />
+                      Repetir
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+          </CollapsibleTrigger>
+          
+          <CollapsibleContent className="mt-4">
+            <Separator className="mb-4" />
+            <div className="space-y-3">
+              <h4 className="font-medium text-gray-900">Detalhes do Pedido</h4>
+              
+              {loadingItems ? (
+                <div className="text-center py-4">
+                  <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary mx-auto"></div>
+                  <p className="text-sm text-gray-500 mt-2">Carregando itens...</p>
+                </div>
+              ) : orderItems.length > 0 ? (
+                <div className="space-y-2">
+                  {orderItems.map((item: any) => (
+                    <div key={item.id} className="flex justify-between items-center py-2 border-b border-gray-100 last:border-b-0">
+                      <div className="flex-1">
+                        <p className="font-medium text-sm">{getProductName(item.product_id)}</p>
+                        <p className="text-sm text-gray-500">
+                          {item.quantity}x {formatCurrency(item.unit_price)}
+                        </p>
+                        {item.observations && (
+                          <p className="text-xs text-gray-400 mt-1">Obs: {item.observations}</p>
+                        )}
+                      </div>
+                      <span className="font-medium text-sm">
+                        {formatCurrency(item.total)}
+                      </span>
+                    </div>
+                  ))}
+                  
+                  <div className="pt-3 mt-4 border-t border-gray-200">
+                    <div className="flex justify-between text-sm mb-2">
+                      <span>Subtotal:</span>
+                      <span>{formatCurrency(order.subtotal)}</span>
+                    </div>
+                    {order.delivery_fee > 0 && (
+                      <div className="flex justify-between text-sm mb-2">
+                        <span>Taxa de entrega:</span>
+                        <span>{formatCurrency(order.delivery_fee)}</span>
+                      </div>
+                    )}
+                    {order.discount_amount > 0 && (
+                      <div className="flex justify-between text-sm text-green-600 mb-2">
+                        <span>Desconto:</span>
+                        <span>-{formatCurrency(order.discount_amount)}</span>
+                      </div>
+                    )}
+                    <div className="flex justify-between font-medium text-base pt-3 mt-2 border-t border-gray-200">
+                      <span>Total:</span>
+                      <span>{formatCurrency(order.total)}</span>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500">Não foi possível carregar os itens do pedido.</p>
+              )}
+
+              <div className="bg-gray-50 rounded-lg p-3 mt-4">
+                <h5 className="font-medium text-sm mb-2">Informações de Entrega</h5>
+                <p className="text-sm text-gray-600">
+                  {order.customer_address}
+                  {order.customer_complement && `, ${order.customer_complement}`}
+                </p>
+                <p className="text-sm text-gray-600">
+                  {order.customer_neighborhood}, {order.customer_city} - {order.customer_state}
+                </p>
+                <p className="text-sm text-gray-600">CEP: {order.customer_zip_code}</p>
+                <p className="text-sm text-gray-600 mt-2">
+                  Pagamento: {order.payment_method === 'pix' ? 'PIX' : order.payment_method.toUpperCase()}
+                </p>
+              </div>
+            </div>
+          </CollapsibleContent>
+        </div>
+      </Collapsible>
+    );
+  };
+
+  // Separar pedidos por status
+  const currentOrders = Array.isArray(orders) ? orders.filter(order => 
+    ['PENDING', 'CONFIRMED', 'PREPARING', 'READY', 'OUT_DELIVERY'].includes(order.status)
+  ) : [];
+  
+  const pastOrders = Array.isArray(orders) ? orders.filter(order => 
+    ['DELIVERED', 'CANCELLED'].includes(order.status)
+  ) : [];
+
+  // Estatísticas do cliente
+  const totalOrders = Array.isArray(orders) ? orders.length : 0;
+  const totalSpent = Array.isArray(orders) ? orders.reduce((sum, order) => sum + Number(order.total), 0) : 0;
 
   return (
     <>
@@ -196,135 +433,231 @@ export default function Pedidos() {
         <div className="absolute inset-0 bg-black/60" />
         <div className="relative z-10 px-4">
           <h1 className="text-3xl sm:text-4xl font-bold tracking-tight">Meus Pedidos</h1>
-          <p className="text-sm sm:text-base opacity-90 mt-2">Acompanhe ou repita seus pedidos favoritos</p>
+          <p className="text-sm sm:text-base opacity-90 mt-2">
+            {showSearchForm ? "Digite seu telefone para acessar seus pedidos" : "Acompanhe e repita seus pedidos favoritos"}
+          </p>
         </div>
       </section>
 
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        {/* Page Header */}
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Meus Pedidos</h1>
-          <p className="text-gray-600">Consulte o histórico e status dos seus pedidos</p>
-        </div>
+        
+        {/* Formulário de busca - mostrado apenas se não conhecemos o usuário */}
+        {showSearchForm && (
+          <>
+            {/* Page Header */}
+            <div className="mb-8">
+              <h1 className="text-3xl font-bold text-gray-900 mb-2">Encontre seus Pedidos</h1>
+              <p className="text-gray-600">Digite seu número de telefone para acessar seu histórico</p>
+            </div>
 
-        {/* Search Section */}
-        <Card className="mb-8">
-          <CardHeader>
-            <CardTitle className="flex items-center space-x-2">
-              <Search className="w-5 h-5" />
-              <span>Buscar Pedidos</span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex space-x-4">
-              <Input
-                type="tel"
-                placeholder="Digite seu número de telefone (ex: (11) 99999-9999)"
-                value={customerPhone}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const formatted = formatWhatsApp(e.target.value);
-                  setCustomerPhone(formatted);
-                }}
-                className="flex-1"
-                maxLength={15}
-                onKeyPress={(e) => {
-                  if (e.key === 'Enter') {
-                    handleSearchOrders();
-                  }
-                }}
-              />
-              <Button onClick={handleSearchOrders} className="bg-primary hover:bg-orange-600">
-                Buscar
+            {/* Search Section */}
+            <Card className="mb-8">
+              <CardHeader>
+                <CardTitle className="flex items-center space-x-2">
+                  <Search className="w-5 h-5" />
+                  <span>Buscar Pedidos</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex space-x-4">
+                  <Input
+                    type="tel"
+                    placeholder="Digite seu número de telefone (ex: (11) 99999-9999)"
+                    value={customerPhone}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      const formatted = formatWhatsApp(e.target.value);
+                      setCustomerPhone(formatted);
+                    }}
+                    className="flex-1"
+                    maxLength={15}
+                    onKeyPress={(e) => {
+                      if (e.key === 'Enter') {
+                        handleSearchOrders();
+                      }
+                    }}
+                  />
+                  <Button onClick={handleSearchOrders} className="bg-primary hover:bg-orange-600">
+                    Buscar
+                  </Button>
+                </div>
+                <p className="text-sm text-gray-500 mt-2">
+                  Digite o número de telefone usado nos pedidos para visualizar o histórico
+                </p>
+              </CardContent>
+            </Card>
+
+            {/* Como usar e Status Guide */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+              {/* How to Use Section */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Como usar</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="flex items-start space-x-3">
+                    <div className="flex-shrink-0 w-8 h-8 bg-primary text-white rounded-full flex items-center justify-center text-sm font-bold">
+                      1
+                    </div>
+                    <div>
+                      <h3 className="font-medium">Digite seu telefone</h3>
+                      <p className="text-sm text-gray-600">Use o mesmo número cadastrado nos seus pedidos</p>
+                    </div>
+                  </div>
+                  <div className="flex items-start space-x-3">
+                    <div className="flex-shrink-0 w-8 h-8 bg-primary text-white rounded-full flex items-center justify-center text-sm font-bold">
+                      2
+                    </div>
+                    <div>
+                      <h3 className="font-medium">Visualize seus pedidos</h3>
+                      <p className="text-sm text-gray-600">Veja o histórico completo com status e detalhes</p>
+                    </div>
+                  </div>
+                  <div className="flex items-start space-x-3">
+                    <div className="flex-shrink-0 w-8 h-8 bg-primary text-white rounded-full flex items-center justify-center text-sm font-bold">
+                      3
+                    </div>
+                    <div>
+                      <h3 className="font-medium">Repita pedidos</h3>
+                      <p className="text-sm text-gray-600">Refaça pedidos anteriores com um clique</p>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Status Guide */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Status dos Pedidos</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-3">
+                    <div className="flex items-center space-x-3">
+                      {getStatusIcon('PENDING')}
+                      <span className="text-sm">Pendente - Aguardando confirmação</span>
+                    </div>
+                    <div className="flex items-center space-x-3">
+                      {getStatusIcon('CONFIRMED')}
+                      <span className="text-sm">Confirmado - Pedido aceito</span>
+                    </div>
+                    <div className="flex items-center space-x-3">
+                      {getStatusIcon('PREPARING')}
+                      <span className="text-sm">Preparando - Em produção</span>
+                    </div>
+                    <div className="flex items-center space-x-3">
+                      {getStatusIcon('READY')}
+                      <span className="text-sm">Pronto - Aguardando retirada/entrega</span>
+                    </div>
+                    <div className="flex items-center space-x-3">
+                      {getStatusIcon('OUT_DELIVERY')}
+                      <span className="text-sm">Saiu para entrega - A caminho</span>
+                    </div>
+                    <div className="flex items-center space-x-3">
+                      {getStatusIcon('DELIVERED')}
+                      <span className="text-sm">Entregue - Pedido finalizado</span>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </>
+        )}
+
+        {/* Área dos pedidos - mostrada quando conhecemos o usuário */}
+        {!showSearchForm && currentCustomerId && (
+          <>
+            {/* Header com informações do cliente */}
+            <div className="flex justify-between items-start mb-8">
+              <div>
+                <h1 className="text-3xl font-bold text-gray-900 mb-2">Seus Pedidos</h1>
+                <div className="flex items-center space-x-4 text-gray-600">
+                  <div className="flex items-center space-x-1">
+                    <User className="w-4 h-4" />
+                    <span>{knownCustomerPhone}</span>
+                  </div>
+                  {totalOrders > 0 && (
+                    <>
+                      <span>•</span>
+                      <span>{totalOrders} pedido{totalOrders > 1 ? 's' : ''}</span>
+                      <span>•</span>
+                      <span>Total gasto: {formatCurrency(totalSpent)}</span>
+                    </>
+                  )}
+                </div>
+              </div>
+              <Button variant="outline" onClick={handleLogout} size="sm">
+                <LogOut className="w-4 h-4 mr-2" />
+                Trocar Usuário
               </Button>
             </div>
-            <p className="text-sm text-gray-500 mt-2">
-              Digite o número de telefone usado nos pedidos para visualizar o histórico
-            </p>
-          </CardContent>
-        </Card>
 
-        {/* How to Use Section */}
-        <Card className="mb-8">
-          <CardHeader>
-            <CardTitle>Como usar</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-start space-x-3">
-              <div className="flex-shrink-0 w-8 h-8 bg-primary text-white rounded-full flex items-center justify-center text-sm font-bold">
-                1
+            {/* Loading State */}
+            {isLoadingOrders && (
+              <div className="text-center py-12">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
+                <p className="mt-4 text-gray-500">Carregando seus pedidos...</p>
               </div>
-              <div>
-                <h3 className="font-medium">Digite seu telefone</h3>
-                <p className="text-sm text-gray-600">Use o mesmo número cadastrado nos seus pedidos</p>
-              </div>
-            </div>
-            <div className="flex items-start space-x-3">
-              <div className="flex-shrink-0 w-8 h-8 bg-primary text-white rounded-full flex items-center justify-center text-sm font-bold">
-                2
-              </div>
-              <div>
-                <h3 className="font-medium">Visualize seus pedidos</h3>
-                <p className="text-sm text-gray-600">Veja o histórico completo com status e detalhes</p>
-              </div>
-            </div>
-            <div className="flex items-start space-x-3">
-              <div className="flex-shrink-0 w-8 h-8 bg-primary text-white rounded-full flex items-center justify-center text-sm font-bold">
-                3
-              </div>
-              <div>
-                <h3 className="font-medium">Repita pedidos</h3>
-                <p className="text-sm text-gray-600">Refaça pedidos anteriores com um clique</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+            )}
 
-        {/* Status Guide */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Status dos Pedidos</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="flex items-center space-x-3">
-                {getStatusIcon('PENDING')}
-                <span className="text-sm">Pendente - Aguardando confirmação</span>
+            {/* Pedidos Atuais */}
+            {currentOrders.length > 0 && (
+              <div className="mb-8">
+                <h2 className="text-xl font-semibold text-gray-900 mb-4 flex items-center">
+                  <Package className="w-5 h-5 mr-2 text-primary" />
+                  Pedidos em Andamento
+                </h2>
+                <div className="space-y-4">
+                  {currentOrders.map((order) => (
+                    <OrderDetails key={order.id} order={order} />
+                  ))}
+                </div>
               </div>
-              <div className="flex items-center space-x-3">
-                {getStatusIcon('CONFIRMED')}
-                <span className="text-sm">Confirmado - Pedido aceito</span>
-              </div>
-              <div className="flex items-center space-x-3">
-                {getStatusIcon('PREPARING')}
-                <span className="text-sm">Preparando - Em produção</span>
-              </div>
-              <div className="flex items-center space-x-3">
-                {getStatusIcon('READY')}
-                <span className="text-sm">Pronto - Aguardando retirada/entrega</span>
-              </div>
-              <div className="flex items-center space-x-3">
-                {getStatusIcon('OUT_DELIVERY')}
-                <span className="text-sm">Saiu para entrega - A caminho</span>
-              </div>
-              <div className="flex items-center space-x-3">
-                {getStatusIcon('DELIVERED')}
-                <span className="text-sm">Entregue - Pedido finalizado</span>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+            )}
 
-        {/* Order History Modal */}
-        <OrderHistoryModal
-          isOpen={isOrderHistoryOpen}
-          onClose={() => setIsOrderHistoryOpen(false)}
-          customerId={currentCustomerId}
-          onRepeatOrder={handleRepeatOrder}
-          onContinueShopping={() => {
-            setIsOrderHistoryOpen(false);
-            window.location.href = '/cardapio';
-          }}
-        />
+            {/* Pedidos Anteriores */}
+            {pastOrders.length > 0 && (
+              <div className="mb-8">
+                <h2 className="text-xl font-semibold text-gray-900 mb-4 flex items-center">
+                  <History className="w-5 h-5 mr-2 text-primary" />
+                  Histórico de Pedidos
+                </h2>
+                <div className="space-y-4">
+                  {pastOrders.map((order) => (
+                    <OrderDetails key={order.id} order={order} />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Sem pedidos */}
+            {!isLoadingOrders && orders.length === 0 && (
+              <div className="text-center py-12">
+                <History className="w-16 h-16 mx-auto text-gray-300 mb-4" />
+                <h3 className="text-xl font-semibold text-gray-900 mb-2">Nenhum pedido encontrado</h3>
+                <p className="text-gray-500 mb-6">Você ainda não fez nenhum pedido conosco</p>
+                <Button 
+                  onClick={() => window.location.href = '/cardapio'}
+                  className="bg-primary hover:bg-orange-600"
+                >
+                  <ShoppingCart className="w-4 h-4 mr-2" />
+                  Fazer Primeiro Pedido
+                </Button>
+              </div>
+            )}
+
+            {/* Botões de ação */}
+            {orders.length > 0 && (
+              <div className="flex justify-center space-x-4 pt-8 border-t border-gray-200">
+                <Button 
+                  onClick={() => window.location.href = '/cardapio'}
+                  className="bg-primary hover:bg-orange-600"
+                >
+                  <ShoppingCart className="w-4 h-4 mr-2" />
+                  Fazer Novo Pedido
+                </Button>
+              </div>
+            )}
+          </>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Make `/pedidos` page dynamic to show user orders directly or a search form, replacing the order history modal.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous flow required a pop-up after payment to show order history. This change integrates the order display directly into the `/pedidos` page, using `localStorage` to remember known users and automatically show their orders. This streamlines the post-payment experience and provides a dedicated "My Orders" view, eliminating friction for returning customers.